### PR TITLE
Implement libcloud storage backend

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -49,6 +49,7 @@ The application relies on third party open source libraries to actually
 communicate with cloud datastores, so for each cloud datastore you need the
 corresponding library below:
 
+* Apache Libcloud: `apache-libcloud <https://pypi.org/project/apache-libcloud/>`_
 * Amazon S3 / Google Storage: `boto <http://code.google.com/p/boto/>`_
 * Rackspace Cloud Files / OpenStack Storage:
   `cloudfiles <https://github.com/rackspace/python-cloudfiles>`_
@@ -79,6 +80,9 @@ First, start with edits to your Django project's ``settings.py``::
 In addition, for more security options, the following Cloud Browser options
 may be set via environment variables instead of ``settings.py`` variables:
 
+* ``CLOUD_BROWSER_APACHE_LIBCLOUD_PROVIDER``
+* ``CLOUD_BROWSER_APACHE_LIBCLOUD_ACCOUNT``
+* ``CLOUD_BROWSER_APACHE_LIBCLOUD_SECRET_KEY``
 * ``CLOUD_BROWSER_AWS_ACCOUNT``
 * ``CLOUD_BROWSER_AWS_SECRET_KEY``
 * ``CLOUD_BROWSER_GS_ACCOUNT``

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ well as view / download objects.
 
 Currently supported backend datastores include:
 
+* `Apache Libcloud`_.
 * `Amazon S3`_.
 * `Google Storage for Developers`_.
 * `Rackspace Cloud Files`_.
@@ -20,6 +21,7 @@ Currently supported backend datastores include:
 * `OpenStack Storage`_.
 * Local file system.
 
+.. _`Apache Libcloud`: https://libcloud.readthedocs.io/en/latest/storage/index.html
 .. _`Amazon S3`: http://aws.amazon.com/s3/
 .. _`Google Storage for Developers`: http://code.google.com/apis/storage/
 .. _`Rackspace Cloud Files`:

--- a/cloud_browser/app_settings.py
+++ b/cloud_browser/app_settings.py
@@ -100,6 +100,13 @@ class Settings(object):
 
     * ``CLOUD_BROWSER_DATASTORE``: Choice of datastore (see values below).
 
+    **Apache Libcloud**: Configure Apache Libcloud as backing datastore.
+
+    * ``CLOUD_BROWSER_DATASTORE = "ApacheLibcloud"``
+    * ``CLOUD_BROWSER_APACHE_LIBCLOUD_PROVIDER``: Provider name. (*Env*)
+    * ``CLOUD_BROWSER_APACHE_LIBCLOUD_ACCOUNT``: Account name. (*Env*)
+    * ``CLOUD_BROWSER_APACHE_LIBCLOUD_SECRET_KEY``: Account secret. (*Env*)
+
     **Amazon Web Services**: Configure AWS S3 as backing datastore.
 
     * ``CLOUD_BROWSER_DATASTORE = "AWS"``
@@ -162,6 +169,7 @@ class Settings(object):
     """
     #: Valid datastore types.
     DATASTORES = set((
+        'ApacheLibcloud',
         'AWS',
         'Google',
         'Rackspace',
@@ -175,6 +183,11 @@ class Settings(object):
             default='Filesystem',
             valid_set=DATASTORES
         ),
+
+        # Apache Libcloud datastore settings.
+        'CLOUD_BROWSER_APACHE_LIBCLOUD_PROVIDER': Setting(from_env=True),
+        'CLOUD_BROWSER_APACHE_LIBCLOUD_ACCOUNT': Setting(from_env=True),
+        'CLOUD_BROWSER_APACHE_LIBCLOUD_SECRET_KEY': Setting(from_env=True),
 
         # Amazon Web Services S3 datastore settings.
         'CLOUD_BROWSER_AWS_ACCOUNT': Setting(from_env=True),

--- a/cloud_browser/cloud/apache_libcloud.py
+++ b/cloud_browser/cloud/apache_libcloud.py
@@ -1,0 +1,167 @@
+"""ApacheLibcloud datastore."""
+from datetime import datetime
+from io import BytesIO
+from itertools import islice
+
+from cloud_browser.app_settings import settings
+from cloud_browser.cloud import errors, base
+from cloud_browser.common import requires, SEP
+
+###############################################################################
+# Constants / Conditional Imports
+###############################################################################
+try:
+    import libcloud  # pylint: disable=F0401
+except ImportError:
+    libcloud = None  # pylint: disable=C0103
+
+DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %Z'
+
+
+###############################################################################
+# Classes
+###############################################################################
+class ApacheLibcloudExceptionWrapper(errors.CloudExceptionWrapper):
+    """ApacheLibcloud :mod:`cloudfiles` exception translator."""
+
+    @classmethod
+    @requires(libcloud, 'libcloud')
+    def lazy_translations(cls):
+        """Lazy translations."""
+
+        return {
+            libcloud.storage.types.ContainerDoesNotExistError:
+                errors.NoContainerException,
+            libcloud.storage.types.ObjectDoesNotExistError:
+                errors.NoObjectException,
+        }
+
+
+class ApacheLibcloudObject(base.CloudObject):
+    """ApacheLibcloud object wrapper."""
+
+    def _get_object(self):
+        """Return native storage object."""
+        return self.container.native_container.get_object(self.name)
+
+    def _read(self):
+        """Return contents of object."""
+        stream = self.native_obj.as_stream()
+        content = BytesIO()
+        content.writelines(stream)
+        content.seek(0)
+        return content.read()
+
+    @classmethod
+    def from_libcloud(cls, container, obj):
+        """Create object from `libcloud.storage.base.Object`."""
+
+        try:
+            last_modified = obj.extra['last_modified']
+            last_modified = datetime.strptime(last_modified, DATE_FORMAT)
+        except (KeyError, ValueError):
+            last_modified = None
+
+        return cls(
+            container,
+            name=obj.name,
+            size=obj.size,
+            content_encoding=obj.extra.get('content_encoding'),
+            content_type=obj.extra.get('content_type'),
+            last_modified=last_modified,
+            obj_type=cls.type_cls.FILE,
+        )
+
+
+class ApacheLibcloudContainer(base.CloudContainer):
+    """ApacheLibcloud container wrapper."""
+    #: Storage object child class.
+    obj_cls = ApacheLibcloudObject
+
+    #: Exception translations.
+    wrap_libcloud_errors = ApacheLibcloudExceptionWrapper()
+
+    def _get_container(self):
+        """Return native container object."""
+        return self.conn.native_conn.get_container(self.name)
+
+    @wrap_libcloud_errors
+    def get_objects(self, path, marker=None,
+                    limit=settings.CLOUD_BROWSER_DEFAULT_LIST_LIMIT):
+        """Get objects."""
+        client = self.conn.native_conn
+        path = path.rstrip(SEP) + SEP if path else ''
+        dirs = set()
+
+        def get_files_and_directories(items):
+            for item in items:
+                suffix = item.name[len(path):]
+                subdirs = suffix.split(SEP)
+                is_file = len(subdirs) == 1
+
+                if is_file:
+                    yield self.obj_cls.from_libcloud(self, item)
+                    continue
+
+                subdir = subdirs[0]
+                if subdir in dirs:
+                    continue
+
+                dirs.add(subdir)
+                yield self.obj_cls(
+                    self,
+                    name=(path + SEP + subdir).lstrip(SEP),
+                    obj_type=self.obj_cls.type_cls.SUBDIR,
+                )
+
+        objs = client.iterate_container_objects(self.native_container, path)
+        objs = get_files_and_directories(objs)
+        objs = islice(objs, limit)
+
+        return list(objs)
+
+    @wrap_libcloud_errors
+    def get_object(self, path):
+        """Get single object."""
+        obj = self.native_container.get_object(path)
+        return self.obj_cls.from_libcloud(self, obj)
+
+    @classmethod
+    def from_libcloud(cls, conn, container):
+        """Create container from `libcloud.storage.base.Container`."""
+        return cls(conn, container.name)
+
+
+class ApacheLibcloudConnection(base.CloudConnection):
+    """ApacheLibcloud connection wrapper."""
+    #: Container child class.
+    cont_cls = ApacheLibcloudContainer
+
+    #: Exception translations.
+    wrap_libcloud_errors = ApacheLibcloudExceptionWrapper()
+
+    def __init__(self, provider, account, secret_key):
+        """Initializer."""
+        super(ApacheLibcloudConnection, self).__init__(account, secret_key)
+        self.provider = provider
+
+    @wrap_libcloud_errors
+    @requires(libcloud, 'libcloud')
+    def _get_connection(self):
+        """Return native connection object."""
+        driver = libcloud.get_driver(libcloud.DriverType.STORAGE,
+                                     self.provider.lower())
+
+        return driver(self.account, self.secret_key)
+
+    @wrap_libcloud_errors
+    def _get_containers(self):
+        """Return available containers."""
+        return [self.cont_cls.from_libcloud(self, container)
+                for container in self.native_conn.iterate_containers()]
+
+    @wrap_libcloud_errors
+    def _get_container(self, path):
+        """Return single container."""
+        container = self.native_conn.get_container(path)
+        return self.cont_cls.from_libcloud(self, container)

--- a/cloud_browser/cloud/config.py
+++ b/cloud_browser/cloud/config.py
@@ -15,6 +15,19 @@ class Config(object):
 
         conn_cls = conn_fn = None
         datastore = settings.CLOUD_BROWSER_DATASTORE
+
+        if datastore == 'ApacheLibcloud':
+            # Try ApacheLibcloud
+            from cloud_browser.cloud.apache_libcloud import \
+                ApacheLibcloudConnection
+            provider = settings.CLOUD_BROWSER_APACHE_LIBCLOUD_PROVIDER
+            account = settings.CLOUD_BROWSER_APACHE_LIBCLOUD_ACCOUNT
+            secret_key = settings.CLOUD_BROWSER_APACHE_LIBCLOUD_SECRET_KEY
+            if provider and account and secret_key:
+                conn_cls = ApacheLibcloudConnection
+                conn_fn = lambda: ApacheLibcloudConnection(
+                    provider, account, secret_key)
+
         if datastore == 'AWS':
             # Try AWS
             from cloud_browser.cloud.aws import AwsConnection

--- a/doc/cloud_browser/cloud.rst
+++ b/doc/cloud_browser/cloud.rst
@@ -32,6 +32,11 @@ Filesystem Datastore
 .. automodule:: cloud_browser.cloud.fs
    :members:
 
+Apache Libcloud Datastore
+-------------------------
+.. automodule:: cloud_browser.cloud.apache_libcloud
+   :members:
+
 Boto-based Datastore Abstract Base Class
 ----------------------------------------
 .. automodule:: cloud_browser.cloud.boto_base


### PR DESCRIPTION
This pull request implements a new storage backend based on [Apache Libcloud](https://libcloud.readthedocs.io/en/latest/storage/index.html) which is a cloud abstraction API library that offers a unified interface to [a large variety of cloud providers](https://libcloud.readthedocs.io/en/latest/storage/supported_providers.html) including AWS S3, Google Cloud Storage, OpenStack Swift, Azure Blob Storage, etc. This unlocks a bunch of new clouds as backends for this project which previously weren't supported.

Tested with:
- `apache-libcloud==2.4.0`
- `CLOUD_BROWSER_APACHE_LIBCLOUD_PROVIDER=AZURE_BLOBS`