### PR TITLE
Add option to redirect to custom object view

### DIFF
--- a/cloud_browser/app_settings.py
+++ b/cloud_browser/app_settings.py
@@ -155,6 +155,10 @@ class Settings(object):
 
     * ``CLOUD_BROWSER_DEFAULT_LIST_LIMIT``: Default number of objects to
       diplay per browser page.
+
+    * ``CLOUD_BROWSER_OBJECT_REDIRECT_URL``: Custom URL to which to redirect
+      when clicking on an object (defaults to showing object contents).
+
     * ``CLOUD_BROWSER_STATIC_MEDIA_DIR``: If this applications static media
       (found in ``app_media``) is served up under the ``settings.MEDIA_ROOT``,
       then set a relative path from the root, and the static media will be used
@@ -202,6 +206,9 @@ class Settings(object):
 
         # Browser settings.
         'CLOUD_BROWSER_DEFAULT_LIST_LIMIT': Setting(default=20),
+
+        # Hook for custom actions.
+        'CLOUD_BROWSER_OBJECT_REDIRECT_URL': Setting(),
 
         # Static media root.
         'CLOUD_BROWSER_STATIC_MEDIA_DIR': Setting(),

--- a/cloud_browser/urls.py
+++ b/cloud_browser/urls.py
@@ -1,17 +1,13 @@
 """Cloud browser URLs."""
 from django.conf.urls import url
-from django.views.generic.base import RedirectView
 from django.views.static import serve
 
 from cloud_browser.app_settings import settings
-from cloud_browser.views import browser, document
+from cloud_browser.views import browser, document, index
 
 # pylint: disable=invalid-name
 urlpatterns = [
-    url(r'^$',
-        # pylint: disable=no-value-for-parameter
-        RedirectView.as_view(url='browser'),
-        name="cloud_browser_index"),
+    url(r'^$', index, name="cloud_browser_index"),
     url(r'^browser/(?P<path>.*)$', browser, name="cloud_browser_browser"),
     url(r'^document/(?P<path>.*)$', document, name="cloud_browser_document"),
 ]

--- a/cloud_browser/urls_admin.py
+++ b/cloud_browser/urls_admin.py
@@ -1,18 +1,14 @@
 """Cloud browser URLs for Django admin integration."""
 from django.conf.urls import url
-from django.views.generic.base import RedirectView
 from django.views.static import serve
 
 from cloud_browser.app_settings import settings
-from cloud_browser.views import browser, document
+from cloud_browser.views import browser, document, index
 
 # pylint: disable=invalid-name
 
 urlpatterns = [
-    url(r'^$',
-        # pylint: disable=no-value-for-parameter
-        RedirectView.as_view(url='browser'),
-        name="cloud_browser_index"),
+    url(r'^$', index, name="cloud_browser_index"),
     url(r'^browser/(?P<path>.*)$', browser, name="cloud_browser_browser",
         kwargs={'template': "cloud_browser/admin/browser.html"}),
     url(r'^document/(?P<path>.*)$', document, name="cloud_browser_document"),

--- a/cloud_browser/views.py
+++ b/cloud_browser/views.py
@@ -1,6 +1,7 @@
 """Cloud browser views."""
 from django.http import HttpResponse, Http404
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.utils.http import urlencode
 
 try:
     # pylint: disable=no-name-in-module, import-error
@@ -158,6 +159,13 @@ def document(_, path=''):
         storage_obj = container.get_object(object_path)
     except errors.NoObjectException:
         raise Http404("No object at: %s" % object_path)
+
+    custom_view = settings.CLOUD_BROWSER_OBJECT_REDIRECT_URL
+    if custom_view:
+        return redirect(custom_view + "?" + urlencode({
+            "container": container_path,
+            "object": object_path,
+        }))
 
     # Get content-type and encoding.
     content_type = storage_obj.smart_content_type

--- a/cloud_browser/views.py
+++ b/cloud_browser/views.py
@@ -162,7 +162,8 @@ def document(_, path=''):
 
     custom_view = settings.CLOUD_BROWSER_OBJECT_REDIRECT_URL
     if custom_view:
-        return redirect(custom_view + "?" + urlencode({
+        separator = "?" if "?" not in custom_view else "&"
+        return redirect(custom_view + separator + urlencode({
             "container": container_path,
             "object": object_path,
         }))


### PR DESCRIPTION
Currently the cloud browser works very nicely as a stand-alone for exploring object hierarchies in cloud storage, similar to other tools such as the [Azure Storage Explorer](https://azure.microsoft.com/en-us/features/storage-explorer/). To further improve the utility of the cloud browser and make it easier to inter-op with other Django projects, this pull request adds a new setting which enables developers to customize the "leaf node" on-click behavior of the cloud browser.

Currently when a user clicks on a "leaf node" file in the cloud browser, the file's contents are displayed. If the new setting is provided, instead of displaying the file contents, the request is redirected to an arbitrary URL passing the full context information for the file. This is useful for scenarios where the cloud browser is embedded in a larger application, e.g. for user flows such as "on this button click, open the cloud browser (host app context)" then "navigate to a file in the browser and click on it (cloud_browser app context)" and finally "parse the file and import it into a database (host app context)".

To enable continuity between context when the cloud browser is entered and exited, any metadata that is passed via query parameters to the first call of the cloud browser is persisted in the session and passed to the caller on cloud browser exit.