### PR TITLE
Automate publishing to PyPI and gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,35 @@ before_install:
 
 script:
   - "fab check"
+
+cache: pip
+sudo: required
+
+before_deploy:
+  - git config --global user.name "Travis CI"
+  - git config --global user.email "travis@travis-ci.org"
+  - curl -sL "https://deb.nodesource.com/setup_8.x" | sudo bash -
+  - sudo apt-get install -y nodejs
+  - sudo npm install --global gh-pages@2.0.1
+
+deploy:
+  - provider: script
+    script: fab upload
+    on:
+      tags: true
+      python: "3.6"
+
+  - provider: script
+    script: fab docs publish_docs
+    on:
+      tags: true
+      python: "3.6"
+
+env:
+  global:
+    # TWINE_USERNAME
+    - secure: "UDqGCBOaIluq9GLxjGNMqNsYmgLl8tgBaA48aZFVvo1A+OOftAKz4SxcrxX5T6RQk/tyjGmYmsqp29Omfwbs0+HB8ybQa5+Y+yK2zUGq9qlyqQjl4DxLGIoK09yvRizmN4DVjGiiCWuGfLDissztrAs62t0vL4saRXXTItQIy5c="
+    # TWINE_PASSWORD
+    - secure: "jKfYcuOTx3Bp+4iqjOc7npDT30Vm4nqntQSNtuXn8VH1NkrUYhtN8PU7/4uxoH9r0UnNaFDj0JDXqYFKqt/fFQJgJXYQsBOP0oMxPwIzd1t3tvqhyE4Qn+9JJrN8LoQeGtFA+HOiyRNZiWm0WHQyD0LtQWyv7dmezV2r8zc7tL8="
+    # GITHUB_TOKEN
+    - secure: "T6jNcZb+c/J5fhTFCiBo/19APZ3MiI6kQXhPPdA+DAOro2GBRb11mli01cm8CDwJi/uxfDpzo0m3S66vAgLsRR1t9hy2m2773Wc3D05SUjlygHBURKy1MKpkrfypcsmZ28VjJSZBlB2b5VkovvlGcXCCpE2NSwyh0/OioeAWZw0="

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,10 @@ before_deploy:
   - curl -sL "https://deb.nodesource.com/setup_8.x" | sudo bash -
   - sudo apt-get install -y nodejs
   - sudo npm install --global gh-pages@2.0.1
-  - sed -i "s|^VERSION = \(.*\)$|VERSION = (${TRAVIS_TAG//./, })|g" cloud_browser/__init__.py
 
 deploy:
   - provider: script
-    script: fab upload
+    script: fab sdist:version=${TRAVIS_TAG} publish_pypi
     on:
       tags: true
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_deploy:
   - curl -sL "https://deb.nodesource.com/setup_8.x" | sudo bash -
   - sudo apt-get install -y nodejs
   - sudo npm install --global gh-pages@2.0.1
+  - sed -i "s|^VERSION = \(.*\)$|VERSION = (${TRAVIS_TAG//./, })|g" cloud_browser/__init__.py
 
 deploy:
   - provider: script

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,14 @@
+Development setup
+=================
+
+You can set up the project and install development dependencies via:
+
+.. sourcecode :: sh
+
+    pip install -e .[test]
+
+You can also run the CI locally via:
+
+.. sourcecode :: sh
+
+    fab check

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,3 +12,34 @@ You can also run the CI locally via:
 .. sourcecode :: sh
 
     fab check
+
+Publishing a release
+====================
+
+There are two steps required to publish a new release:
+
+1. Generate a Python distribution and upload it to PyPI.
+2. Generate the documentation and upload it to Github Pages.
+
+Both steps are automated via Travis CI and get run whenever
+`a release is created on Github <https://help.github.com/en/articles/creating-releases>`_.
+The tag version of the release will be used as the PyPI version identifier
+and should follow the `semantic versioning <https://semver.org/>`_ convention
+of :code:`major.minor.patch`.
+
+Alternatively, the release steps can also be run locally via:
+
+.. sourcecode :: sh
+
+    # set credentials for PyPI
+    export TWINE_USERNAME="..."
+    export TWINE_PASSWORD="..."
+
+    # set a personal access token with push access to the repo
+    export GITHUB_TOKEN="..."
+
+    # set the new version number
+    export BUILD_VERSION="1.2.3"
+
+    # run the release
+    fab sdist publish_pypi docs publish_docs

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@
 :Info: A Django application browser for cloud (S3, Cloud Files) datastores.
 :Author: Ryan Roemer (http://github.com/ryan-roemer)
 :Build: |travis| |azdo| |style|
+:Version: |version|
 
 Cloud Browser is a simple web-based object browser for cloud-based blob
 datastores. Just add as an application to a Django project, add some settings,
@@ -71,3 +72,6 @@ a long list of results.
 
 .. |style| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/python/black
+
+.. |version| image:: https://img.shields.io/pypi/v/django-cloud-browser.svg
+   :target: https://pypi.org/project/django-cloud-browser/

--- a/cloud_browser/__init__.py
+++ b/cloud_browser/__init__.py
@@ -3,7 +3,7 @@
 Provides a simple filesystem-like browser interface for cloud blob datastores.
 """
 
-VERSION = (0, 4, 0)
+VERSION = (0, 0, 0)  # placeholder, real value is set by `fab sdist`
 
 __version__ = ".".join(str(v) for v in VERSION)
 __version_full__ = __version__

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ PKGS = [x for x in find_packages() if x.split(".")[0] == MOD_NAME]
 TEST_DEPENDENCIES = [
     "Django==1.8.0",
     "boto==2.48.0",
+    "apache-libcloud==2.4.0",
     "Fabric3",
     "pylint",
     "flake8",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ TEST_DEPENDENCIES = [
     "twine",
 ]
 
-if version_info.major > 2:
+if version_info >= (3, 6, 0):
     TEST_DEPENDENCIES.append("black")
 
 


### PR DESCRIPTION
This change automates the release to PyPI and gh-pages: whenever a new tag is pushed or a new release is authored in the Github UI, a new version of the project automatically gets published.