### PR TITLE
Add import style linter

### DIFF
--- a/cloud_browser/app_settings.py
+++ b/cloud_browser/app_settings.py
@@ -1,5 +1,6 @@
 """Application-specific settings."""
 import os
+
 from django.conf import settings as _settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/cloud_browser/cloud/apache_libcloud.py
+++ b/cloud_browser/cloud/apache_libcloud.py
@@ -4,8 +4,8 @@ from io import BytesIO
 from itertools import islice
 
 from cloud_browser.app_settings import settings
-from cloud_browser.cloud import errors, base
-from cloud_browser.common import requires, SEP
+from cloud_browser.cloud import base, errors
+from cloud_browser.common import SEP, requires
 
 ###############################################################################
 # Constants / Conditional Imports

--- a/cloud_browser/cloud/base.py
+++ b/cloud_browser/cloud/base.py
@@ -1,9 +1,9 @@
 """Cloud datastore API base abstraction."""
 import mimetypes
 
-from cloud_browser.cloud import errors
 from cloud_browser.app_settings import settings
-from cloud_browser.common import SEP, path_join, basename
+from cloud_browser.cloud import errors
+from cloud_browser.common import SEP, basename, path_join
 
 
 class CloudObjectTypes(object):

--- a/cloud_browser/cloud/boto_base.py
+++ b/cloud_browser/cloud/boto_base.py
@@ -10,8 +10,8 @@ for Developers. This abstract base class gets most of the common work done.
 .. _boto: http://code.google.com/p/boto/
 """
 from cloud_browser.app_settings import settings
-from cloud_browser.cloud import errors, base
-from cloud_browser.common import SEP, requires, dt_from_header
+from cloud_browser.cloud import base, errors
+from cloud_browser.common import SEP, dt_from_header, requires
 
 ###############################################################################
 # Constants / Conditional Imports

--- a/cloud_browser/cloud/errors.py
+++ b/cloud_browser/cloud/errors.py
@@ -1,6 +1,5 @@
 """Common cloud error wrappers."""
 import sys
-
 from functools import wraps
 from itertools import chain
 

--- a/cloud_browser/cloud/fs.py
+++ b/cloud_browser/cloud/fs.py
@@ -5,9 +5,8 @@ import os
 import re
 
 from cloud_browser.app_settings import settings
-from cloud_browser.cloud import errors, base
+from cloud_browser.cloud import base, errors
 from cloud_browser.common import SEP
-
 
 ###############################################################################
 # Helpers / Constants

--- a/cloud_browser/cloud/rackspace.py
+++ b/cloud_browser/cloud/rackspace.py
@@ -12,8 +12,8 @@
 .. _cloudfiles: https://github.com/rackspace/python-cloudfiles
 """
 from cloud_browser.app_settings import settings
-from cloud_browser.cloud import errors, base
-from cloud_browser.common import SEP, check_version, requires, dt_from_header
+from cloud_browser.cloud import base, errors
+from cloud_browser.common import SEP, check_version, dt_from_header, requires
 
 ###############################################################################
 # Constants / Conditional Imports

--- a/cloud_browser/common.py
+++ b/cloud_browser/common.py
@@ -4,8 +4,8 @@ Because cloud operations are OS agnostic, we don't use any of :mod:`os` or
 :mod:`os.path`.
 """
 from datetime import datetime
-from django.core.exceptions import ImproperlyConfigured
 
+from django.core.exceptions import ImproperlyConfigured
 
 ###############################################################################
 # Constants.

--- a/cloud_browser/templatetags/cloud_browser_extras.py
+++ b/cloud_browser/templatetags/cloud_browser_extras.py
@@ -2,7 +2,7 @@
 import os
 
 from django import template
-from django.template import TemplateSyntaxError, Node
+from django.template import Node, TemplateSyntaxError
 from django.template.defaultfilters import stringfilter
 
 from cloud_browser.app_settings import settings

--- a/cloud_browser/views.py
+++ b/cloud_browser/views.py
@@ -1,19 +1,19 @@
 """Cloud browser views."""
 import json
 
-from django.http import HttpResponse, Http404
-from django.shortcuts import render, redirect
+from django.http import Http404, HttpResponse
+from django.shortcuts import redirect, render
 from django.utils.http import urlencode
 
+from cloud_browser.app_settings import settings
+from cloud_browser.cloud import errors, get_connection, get_connection_cls
+from cloud_browser.common import get_int, path_join, path_parts, path_yield, relpath
+
 try:
-    # pylint: disable=no-name-in-module, import-error
+    # pylint: disable=no-name-in-module, import-error, ungrouped-imports
     from django.utils.importlib import import_module
 except ImportError:
     from importlib import import_module
-
-from cloud_browser.app_settings import settings
-from cloud_browser.cloud import get_connection, get_connection_cls, errors
-from cloud_browser.common import get_int, path_parts, path_join, path_yield, relpath
 
 
 MAX_LIMIT = get_connection_cls().cont_cls.max_list

--- a/cloud_browser_project/urls.py
+++ b/cloud_browser_project/urls.py
@@ -2,7 +2,7 @@
 import os
 
 from django.conf import settings
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import RedirectView
 

--- a/dev/.isort.cfg
+++ b/dev/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+line_length = 88

--- a/fabfile.py
+++ b/fabfile.py
@@ -103,7 +103,7 @@ def sdist(version=BUILD_VERSION):
     :param version: Optional version to set before packaging.
     """
     with _update_version(version), _dist_wrapper():
-        local("python setup.py sdist", capture=False)
+        local("python setup.py sdist")
 
 
 def register():
@@ -113,12 +113,12 @@ def register():
         http://stackoverflow.com/questions/1569315
     """
     with _dist_wrapper():
-        local("python setup.py register", capture=False)
+        local("python setup.py register")
 
 
 def publish_pypi():
     """Upload package."""
-    local("twine upload dist/*", capture=False)
+    local("twine upload dist/*")
 
 
 ###############################################################################
@@ -130,7 +130,7 @@ def pylint(rcfile=PYLINT_CFG):
     :param rcfile: PyLint configuration file.
     """
     # Have a spurious DeprecationWarning in pylint.
-    local("pylint --rcfile=%s %s" % (rcfile, " ".join(CHECK_INCLUDES)), capture=False)
+    local("pylint --rcfile=%s %s" % (rcfile, " ".join(CHECK_INCLUDES)))
 
 
 def flake8(rcfile=FLAKE8_CFG):
@@ -138,13 +138,13 @@ def flake8(rcfile=FLAKE8_CFG):
 
     :param rcfile: Flake8 configuration file.
     """
-    local("flake8 --config=%s %s" % (rcfile, " ".join(CHECK_INCLUDES)), capture=False)
+    local("flake8 --config=%s %s" % (rcfile, " ".join(CHECK_INCLUDES)))
 
 
 def black():
     """Run black style checker."""
     if sys.version_info.major > 2:
-        local("black --check %s" % (" ".join(CHECK_INCLUDES)), capture=False)
+        local("black --check %s" % (" ".join(CHECK_INCLUDES)))
 
 
 def check():
@@ -174,7 +174,7 @@ def docs(output=DOC_OUTPUT, proj_settings=PROJ_SETTINGS):
     os.environ["PYTHONPATH"] = ROOT_DIR
     os.environ["DJANGO_SETTINGS_MODULE"] = proj_settings
 
-    local("sphinx-build -b html %s %s" % (DOC_INPUT, output), capture=False)
+    local("sphinx-build -b html %s %s" % (DOC_INPUT, output))
 
 
 def publish_docs(
@@ -205,7 +205,7 @@ def _manage(target, extra=""):
     """Generic wrapper for ``manage.py``."""
     os.environ["PYTHONPATH"] = ROOT_DIR
 
-    local("python %s %s %s" % (MANAGE, target, extra), capture=False)
+    local("python %s %s %s" % (MANAGE, target, extra))
 
 
 def syncdb():

--- a/fabfile.py
+++ b/fabfile.py
@@ -6,7 +6,7 @@ import errno
 from fileinput import FileInput
 import os
 import shutil
-import sys
+from sys import version_info
 from contextlib import contextmanager
 from uuid import uuid4
 
@@ -143,7 +143,7 @@ def flake8(rcfile=FLAKE8_CFG):
 
 def black():
     """Run black style checker."""
-    if sys.version_info.major > 2:
+    if version_info >= (3, 6, 0):
         local("black --check %s" % (" ".join(CHECK_INCLUDES)))
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,17 +1,15 @@
 """Fabric file."""
-from __future__ import with_statement
-from __future__ import print_function
+from __future__ import print_function, with_statement
 
 import errno
-from fileinput import FileInput
 import os
 import shutil
-from sys import version_info
 from contextlib import contextmanager
+from fileinput import FileInput
+from sys import version_info
 from uuid import uuid4
 
 from fabric.api import local
-
 
 ###############################################################################
 # Constants
@@ -27,6 +25,7 @@ DEV_DB_DIR = os.path.join(PROJ, "db")
 CHECK_INCLUDES = ("fabfile.py", "setup.py", MOD, PROJ)
 PYLINT_CFG = os.path.join("dev", "pylint.cfg")
 FLAKE8_CFG = os.path.join("dev", "flake8.cfg")
+ISORT_CFG = os.path.join("dev", ".isort.cfg")
 
 DOC_INPUT = "doc"
 DOC_OUTPUT = "doc_html"
@@ -141,6 +140,21 @@ def flake8(rcfile=FLAKE8_CFG):
     local("flake8 --config=%s %s" % (rcfile, " ".join(CHECK_INCLUDES)))
 
 
+def isort(rcfile=ISORT_CFG):
+    """Run isort style checker.
+
+    :param rcfile: isort configuration file.
+    """
+
+    # use dirname until https://github.com/timothycrosley/isort/issues/710 is resolved
+    rcfile = os.path.dirname(rcfile)
+
+    local(
+        "isort --recursive --check-only --settings-path=%s %s"
+        % (rcfile, " ".join(CHECK_INCLUDES))
+    )
+
+
 def black():
     """Run black style checker."""
     if version_info >= (3, 6, 0):
@@ -150,6 +164,7 @@ def black():
 def check():
     """Run all checkers."""
     flake8()
+    isort()
     black()
     pylint()
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 """Cloud browser package."""
 from __future__ import with_statement
+
 import os
 from sys import version_info
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from cloud_browser import __version__
 
@@ -23,6 +24,7 @@ TEST_DEPENDENCIES = [
     "apache-libcloud==2.4.0",
     "Fabric3",
     "pylint",
+    "isort",
     "flake8",
     "Sphinx",
     "sphinx-bootstrap-theme",


### PR DESCRIPTION
In addition to using black for general code style, we can also use [isort](https://github.com/timothycrosley/isort) to ensure that imports are always consistently sorted. This pull request adds isort to the CI and fixes all the import style lint errors.